### PR TITLE
add ErrConflict (409) and ErrUnavailable (503) sentinels

### DIFF
--- a/EXTEND.md
+++ b/EXTEND.md
@@ -226,7 +226,28 @@ Each endpoint struct has four methods:
 - Checks the JWT if `Auth()` returns `true`
 - Calls `Handle(ctx, req)`
 - Encodes the response as JSON
-- On error: maps the error to an appropriate HTTP status
+- On error: maps the error to an appropriate HTTP status (see below)
+
+**Error responses:** return one of the framework's sentinel errors (directly or wrapped with `%w`) to control the status code; any other error is `500`.
+
+| Return | Status |
+|---|---|
+| `api.ErrBadRequest` | 400 Bad Request |
+| `api.ErrForbidden` | 403 Forbidden |
+| `api.ErrNotFound` | 404 Not Found |
+| `api.ErrConflict` | 409 Conflict |
+| `api.ErrUnavailable` | 503 Service Unavailable |
+| any other `error` | 500 Internal Server Error |
+
+```go
+func (e GetOrderEndpoint) Handle(ctx context.Context, req GetOrderReq) (GetOrderResp, error) {
+    order, err := db.GetOrder(ctx, req.ID)
+    if errors.Is(err, sql.ErrNoRows) {
+        return GetOrderResp{}, fmt.Errorf("order %s: %w", req.ID, api.ErrNotFound) // → 404
+    }
+    return GetOrderResp{Order: order}, err
+}
+```
 
 **Request type struct tags:**
 ```go

--- a/api/errors.go
+++ b/api/errors.go
@@ -8,22 +8,30 @@ import (
 	"net/http"
 )
 
-// Sentinel errors that handlers can return to produce specific HTTP status codes.
+// Sentinel errors that handlers can return (directly or wrapped with %w) to
+// produce specific HTTP status codes.
 var (
-	ErrNotFound   = errors.New("not found")
-	ErrBadRequest = errors.New("bad request")
-	ErrForbidden  = errors.New("forbidden")
+	ErrBadRequest  = errors.New("bad request") // 400
+	ErrForbidden   = errors.New("forbidden")   // 403
+	ErrNotFound    = errors.New("not found")   // 404
+	ErrConflict    = errors.New("conflict")    // 409
+	ErrUnavailable = errors.New("unavailable") // 503
 )
 
-// statusFor maps a handler error to an HTTP status code.
+// statusFor maps a handler error to an HTTP status code. Unrecognized errors
+// map to 500.
 func statusFor(err error) int {
 	switch {
-	case errors.Is(err, ErrNotFound):
-		return http.StatusNotFound
 	case errors.Is(err, ErrBadRequest):
 		return http.StatusBadRequest
 	case errors.Is(err, ErrForbidden):
 		return http.StatusForbidden
+	case errors.Is(err, ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, ErrConflict):
+		return http.StatusConflict
+	case errors.Is(err, ErrUnavailable):
+		return http.StatusServiceUnavailable
 	default:
 		return http.StatusInternalServerError
 	}

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,34 @@
+// Part of the schemaf framework — https://github.com/flocko-motion/schemaf
+// Read the docs, report bugs and feature requests as GitHub issues. We respond quickly.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestStatusFor(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"bad request", ErrBadRequest, http.StatusBadRequest},
+		{"forbidden", ErrForbidden, http.StatusForbidden},
+		{"not found", ErrNotFound, http.StatusNotFound},
+		{"conflict", ErrConflict, http.StatusConflict},
+		{"unavailable", ErrUnavailable, http.StatusServiceUnavailable},
+		{"unknown -> 500", errors.New("boom"), http.StatusInternalServerError},
+		// Handlers usually wrap sentinels for context; errors.Is must still match.
+		{"wrapped conflict", fmt.Errorf("saving order: %w", ErrConflict), http.StatusConflict},
+		{"wrapped unavailable", fmt.Errorf("db down: %w", ErrUnavailable), http.StatusServiceUnavailable},
+	}
+	for _, c := range cases {
+		if got := statusFor(c.err); got != c.want {
+			t.Errorf("%s: statusFor = %d, want %d", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Requested for reads/lifecycle endpoints. Keeps handlers typed instead of HandleRaw.