### PR TITLE
upgrade accepts a bare version (normalize to vX.Y.Z)

### DIFF
--- a/cli/cmd/codegen/schemaf.sh.tmpl
+++ b/cli/cmd/codegen/schemaf.sh.tmpl
@@ -107,6 +107,8 @@ case "$CMD" in
         exit 1
       fi
     fi
+    # Accept a bare version ("1.9.0") as well as "v1.9.0" — Go needs the v prefix.
+    case "$TARGET" in [0-9]*) TARGET="v$TARGET" ;; esac
     echo "Upgrading schemaf framework to ${TARGET}..."
     cd go
     OLD_VER=$(go list -m -f '{{"{{"}}.Version{{"}}"}}' github.com/flocko-motion/schemaf 2>/dev/null || echo "unknown")

--- a/schemaf.sh
+++ b/schemaf.sh
@@ -107,6 +107,8 @@ case "$CMD" in
         exit 1
       fi
     fi
+    # Accept a bare version ("1.9.0") as well as "v1.9.0" — Go needs the v prefix.
+    case "$TARGET" in [0-9]*) TARGET="v$TARGET" ;; esac
     echo "Upgrading schemaf framework to ${TARGET}..."
     cd go
     OLD_VER=$(go list -m -f '{{.Version}}' github.com/flocko-motion/schemaf 2>/dev/null || echo "unknown")


### PR DESCRIPTION
go get needs the v prefix; normalize bare versions.